### PR TITLE
Implement TCP port scanner with open/closed detection and unit tests.

### DIFF
--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -1,0 +1,47 @@
+import unittest
+import socket
+import threading
+from scanner import scan_port
+from utils.common_ports import resolve_service
+
+
+class TestPortScanner(unittest.TestCase):
+
+    def test_valid_open_port(self):
+        def run_server():
+            server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            server.bind(("127.0.0.1", 9999))
+            server.listen(1)
+            conn, _ = server.accept()
+            conn.close()
+            server.close()
+
+        thread = threading.Thread(target=run_server, daemon=True)
+        thread.start()
+
+        status = scan_port("127.0.0.1", 9999)
+        self.assertEqual(status, "open")
+
+    def test_invalid_port(self):
+        with self.assertRaises(ValueError):
+            scan_port("127.0.0.1", -1)
+
+    def test_service_resolution(self):
+        self.assertEqual(resolve_service(80), "HTTP")
+        self.assertEqual(resolve_service(9999), "Unknown")
+
+    def test_valid_ip_address(self):
+        status = scan_port("127.0.0.1", 80)
+        self.assertIn(status, ["open", "closed"])
+
+    def test_valid_hostname(self):
+        status = scan_port("localhost", 80)
+        self.assertIn(status, ["open", "closed"])
+
+    def test_invalid_hostname(self):
+        with self.assertRaises(ValueError):
+            scan_port("not_a_real_host_123", 80)
+
+if __name__ == "__main__":
+    unittest.main()
+

--- a/utils/common_ports.py
+++ b/utils/common_ports.py
@@ -28,3 +28,5 @@ COMMON_PORTS = {
 def get_port_list():
     return list(COMMON_PORTS.keys())
 
+def resolve_service(port):
+    return COMMON_PORTS.get(port, "Unknown")


### PR DESCRIPTION
### Summary

This PR introduces the core TCP port scanning functionality and its supporting unit tests. The scanner reliably determines whether a port is open or closed using socket connections, and includes input validation for invalid ports and targets.

What’s Included:
- Implemented scan_port() to detect open vs closed TCP ports
- Added timeout handling and proper socket cleanup

**Added unit tests to validate:**
- Open port detection
- Closed/invalid port handling
- Service resolution behavior
- Verified tests by intentionally inverting logic to confirm test coverage

**Why This Matters**

This establishes a reliable foundation for future features such as:

- Host validation
- Filtered port detection
- Multi-port scanning
- Reporting and logging enhancements


https://github.com/hmedina24/python-port-scanner/issues/9